### PR TITLE
Change header background to be pure white.

### DIFF
--- a/.changeset/rotten-goats-serve.md
+++ b/.changeset/rotten-goats-serve.md
@@ -1,0 +1,5 @@
+---
+"lightnet": patch
+---
+
+Change header background color to be pure white.

--- a/packages/lightnet/src/layouts/Page.astro
+++ b/packages/lightnet/src/layouts/Page.astro
@@ -36,7 +36,7 @@ const language = resolveLanguage(currentLocale)
   </head>
   <body class="overflow-y-scroll bg-gray-50 text-gray-900">
     <header
-      class="fixed top-0 z-50 h-14 w-full bg-gray-50 shadow-lg sm:h-20"
+      class="fixed top-0 z-50 h-14 w-full bg-white shadow-lg sm:h-20"
       transition:animate="none"
     >
       <div

--- a/packages/lightnet/src/layouts/components/Menu.astro
+++ b/packages/lightnet/src/layouts/components/Menu.astro
@@ -21,7 +21,7 @@ const { icon, label } = Astro.props
 
   <ul
     tabindex="0"
-    class="dy-dropdown-content top-px me-3 mt-[3.25rem] w-48 overflow-hidden rounded-b-md bg-gray-50 py-3 shadow-lg sm:mt-16"
+    class="dy-dropdown-content top-px me-3 mt-[3.25rem] w-48 overflow-hidden rounded-b-md bg-white py-3 shadow-lg sm:mt-16"
   >
     <slot />
   </ul>


### PR DESCRIPTION
It will be less error-prone to add a logo with a white background color.