### PR TITLE
Fix typo in Sk8 Ministries README

### DIFF
--- a/examples/sk8-ministries/README.md
+++ b/examples/sk8-ministries/README.md
@@ -1,6 +1,6 @@
 # Sk8 Ministries Example
 
-This example show cases LightNet´s capabilities with a fictional skateboard ministry.
+This example showcases LightNet´s capabilities with a fictional skateboard ministry.
 View it online at [sk8-ministries.pages.dev](https://sk8-ministries.pages.dev/).
 
 Use this example to explore how to build a LightNet site or as a starting point for your own site. To **create a local copy**, run the following from your terminal:


### PR DESCRIPTION
## Summary
- fix typo in example README

## Testing
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_b_687a371723888322959d83a409199819