### PR TITLE
Add undefined case to markdownToText tests

### DIFF
--- a/packages/lightnet/__tests__/utils/markdown.spec.ts
+++ b/packages/lightnet/__tests__/utils/markdown.spec.ts
@@ -52,3 +52,7 @@ test("Should remove block quotes", () => {
     "block quote\nmore quote",
   )
 })
+
+test("Should return undefined when markdown is undefined", () => {
+  expect(markdownToText(undefined)).toBeUndefined()
+})


### PR DESCRIPTION
## Summary
- add missing test coverage for markdownToText when passed `undefined`

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_b_687a3837e71c8322b8a76d8a6c6dcd84