### PR TITLE
Fix path hint for categories

### DIFF
--- a/packages/lightnet/src/content/get-categories.ts
+++ b/packages/lightnet/src/content/get-categories.ts
@@ -68,6 +68,6 @@ function parseCategory(item: unknown) {
     categoryEntrySchema,
     item,
     (id) => `Invalid category: ${id}`,
-    (id) => `Fix these issues inside "src/content/category/${id}.json":`,
+    (id) => `Fix these issues inside "src/content/categories/${id}.json":`,
   )
 }


### PR DESCRIPTION
## Summary
- adjust parseCategory's file path hint to use `categories/`

## Testing
- `pnpm lint`
- `pnpm --filter lightnet exec vitest run`


------
https://chatgpt.com/codex/tasks/task_b_687a382eeca483228951d2468abd6f8a